### PR TITLE
fix  获取第一个活动的蓝图编辑器 的逻辑BUG

### DIFF
--- a/Source/PuertsTool/Private/PuertsTool.cpp
+++ b/Source/PuertsTool/Private/PuertsTool.cpp
@@ -95,19 +95,22 @@ void FPuertsToolModule::HandleButtonClick(bool bForceOverwrite)
 		// 获取所有打开的蓝图编辑器（返回的是TSharedRef）
 		const TArray<TSharedRef<IBlueprintEditor>>& BlueprintEditors = BlueprintEditorModule->GetBlueprintEditors();
 
-		// 获取第一个活动的蓝图编辑器
+		TSharedPtr<IBlueprintEditor> FocusedEditor;
+		double maxLastActivationTime = 0.0;
+		// 获取最近最新活动的蓝图编辑器
 		for (const TSharedRef<IBlueprintEditor>& Editor : BlueprintEditors)
 		{
-			// 检查编辑器是否有效
-			/*if (Editor.IsValid())
-			{*/
-				// 获取编辑器中的蓝图对象
-				if (FBlueprintEditor* BlueprintEditor = static_cast<FBlueprintEditor*>(&Editor.Get()))
-				{
-					Blueprint = BlueprintEditor->GetBlueprintObj();
-					break;
-				}
-			//}
+			if (Editor->GetLastActivationTime() > maxLastActivationTime)
+			{
+				maxLastActivationTime = Editor->GetLastActivationTime();
+				FocusedEditor = Editor;				
+			}
+		}
+		
+		// 获取编辑器中的蓝图对象
+		if (FBlueprintEditor* BlueprintEditor = static_cast<FBlueprintEditor*>(FocusedEditor.Get()))
+		{
+			Blueprint = BlueprintEditor->GetBlueprintObj();
 		}
 	}
 


### PR DESCRIPTION
fix 获取第一个活动的蓝图编辑器 的逻辑BUG , 
按照第一个活动的蓝图编辑器 , 如果是多个选项卡的情况下 , 会获取不到当前打开的窗口
应该是 获取到当前打开的 聚焦的  的蓝图编辑器